### PR TITLE
Build models from attributes

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -27,6 +27,11 @@ Loader.prototype.loadFixtures = function (fixtures, models, cb) {
 };
 
 Loader.prototype.loadFixture = function (fixture, models, cb) {
+
+    var onError = function(err){
+        throw new Error(JSON.stringify(err));
+    };
+
     if(typeof fixture != 'object') throw new Error('expected fixture to be object, is ' + (typeof fixture));
     else if(!fixture.model) throw new Error('model for a fixture is undefined');
     else if(!fixture.data) throw new Error('data undefined for fixture');
@@ -35,13 +40,24 @@ Loader.prototype.loadFixture = function (fixture, models, cb) {
         throw new Error('Model not found: '+fixture.model);
     } else {
         this.prepFixtureData(fixture.data, Model, function(data){
-            Model.findOrCreate(data, data).success(function(instance, saved){
-                if(saved) self.saved++;
-                else self.skipped++;
-                if(cb) cb();
-            }).error(function(err){
-                throw new Error(err);
+            var where = {};
+            Object.keys(Model.rawAttributes).forEach(function (k) {
+                if(data[k]) where[k] = data[k];
             });
+            Model.find({ where: where }).success(function(instance){
+                if(instance) {
+                    self.skipped++;
+                    if(cb) cb();
+                }
+                else {
+                    Model.build(data).save().success(function (instance) {
+                        if(instance) {
+                            self.saved++;
+                            if(cb) cb();
+                        }
+                    }).error(onError)
+                }
+            }).error(onError);
         });
     }
 };
@@ -69,11 +85,7 @@ Loader.prototype.prepFixtureData = function(data, Model, cb){
                 throw new Error (key+' for '+Model.name+' is type '+(typeof val)+', expected object.');
             }
         } else {
-            if(Model.rawAttributes[key]){
-                result[key] = val;
-            } else {
-                throw new Error('Model '+Model.name+' does not have attribute '+key+'!');
-            }
+            result[key] = val;
         }
     });
 


### PR DESCRIPTION
Using `findOrCreate` for fixture creation disables the use of `setterMethods` during model construction. This change relaxes restrictions on the presence/absence of model attributes and uses `build` to ensure that `setterMethods` can be involved when fixtures are created.

This can wreak havoc if attributes of an existing fixture are updated outside in the database since the last load. If possible, we should construct the `where` only for primary keys (and/or any other immutable constraints).
