### PR TITLE
Allow an external caller to do some transforms to the data

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -48,7 +48,13 @@ Loader.prototype.loadFixture = function (fixture, models, cb) {
 
 Loader.prototype.prepFixtureData = function(data, Model, cb){
     var result = {}, promises = [], errors = [];
-
+    
+    // Allows an external caller to do some transforms to the data 
+    // before it is saved
+    if(this.options.transformFixtureDataFn) {
+        result = this.options.transformFixtureDataFn(data, Model);
+    }
+    
     Object.keys(data).forEach(function(key){
         var assoc = Model.associations[key], val = data[key];
         if(assoc){


### PR DESCRIPTION
Allow an external caller to do some transformations to the data before it is saved, by passing a 'transformFixtureDataFn' function to the options object.

For Example we needed to generate time stamps relative to the time at which the import is run, so that the imported data has differnt time stamps. Eg:
sequelize_fixtures.loadFile('server/fixtures/*.json', models, {
  transformFixtureDataFn: function (data) {
    // Fixtures with negative numbers allow creating data objects
    // relative to the time of the import.
    if(data.createdAt 
     && data.createdAt < 0) { 
      data.createdAt = new Date((new Date()).getTime() + parseFloat(data.createdAt) \* 1000 \* 60);
    }
    return data;
  }
});
