### PR TITLE
Some objects appear to get cached when they are associated

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,35 @@ Assuming `Bar.belongsTo(Foo)`:
 ]
 ```
 
+### Specified keys
+
+Sometimes you want to be quite specific about how things get loaded ID wise because you may have some complex associations that you need to deal with after the basic fixture load. In this instance you can use the IDs to associate simple fixtures to others.
+
+Assuming `Bar.belongsTo(Foo, {as: 'linking_id'})`
+
+```json
+[
+    {
+        "model": "Foo",
+        "data": {
+            "uniqueProp": "FOO1",
+            "uniqueProp2": 1,
+            "propA": "baz",
+            "id": 1 // note the setting of the ID here
+        }
+    },
+    {
+        "model": "Bar",
+        "data": {
+            "propA": "something",
+            "linking_id": 1 // will associate to Foo whose id is 1
+        }
+    }
+]
+
+```
+
+
 # grunt task
 
 Gruntfile.js:

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -74,7 +74,7 @@ Loader.prototype.prepFixtureData = function(data, Model, cb){
     Object.keys(data).forEach(function(key){
         var assoc = Model.associations[key], val = data[key];
         if(assoc){
-            if(typeof val == 'object'){
+            if(typeof val == 'object' || typeof val == 'number'){
                 if(assoc.associationType == 'BelongsTo'){
                     var def = q.defer();
                     promises.push(def.promise);
@@ -88,7 +88,7 @@ Loader.prototype.prepFixtureData = function(data, Model, cb){
                     throw new Error('Only BelongsTo association type is supported for natural keys:(');
                 }
             } else {
-                throw new Error (key+' for '+Model.name+' is type '+(typeof val)+', expected object.');
+                throw new Error (key+' for '+Model.name+' is type '+(typeof val)+', expected object or number.');
             }
         } else {
             result[key] = val;


### PR DESCRIPTION
When creating a reasonable sized fixture I was finding that the objects returned in the promise as a result of the .find() operation appeared to be consistent or else kept returning the first item specified in the database.

This may be a result of a change in Sequelize 2, something to do with sqlite (what I'm using to test) or the vagaries of my specific objects. 

This change allows an ID number to be specified as an alternative to an object as an option for association. This forces the .find(val) to return the specific instance each time and doesn't run into the same problems as before.

Of course this doesn't fix whatever the underlying issue may be but that appears to be out of the skills of by debugging / tracing capability with Node.
