### PR TITLE
Adds the ability to load JavaScript fixture files.

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -17,15 +17,20 @@ var PARSERS = Reader.PARSERS = {
 Reader.prototype.readFile = function(filename, cb){
     this.options.log('Fixtures: reading file '+filename+'...');
     var ext = path.extname(filename).toLowerCase();
-    if(!PARSERS[ext]) {
-        throw new Error('unknown file type: ', ext);
+    if(ext === '.js') {
+        cb(require(path.resolve(process.cwd(), filename)));
     }
-    fs.readFile(filename, this.options.encoding, function(err, data){
-        if(err) throw err;
-        var fixtures = PARSERS[ext](data);
-        if(fixtures.fixtures) fixtures = fixtures.fixtures;
-        cb(fixtures);
-    });
+    else {
+        if(!PARSERS[ext]) {
+            throw new Error('unknown file type: ', ext);
+        }
+        fs.readFile(filename, this.options.encoding, function(err, data){
+            if(err) throw err;
+            var fixtures = PARSERS[ext](data);
+            if(fixtures.fixtures) fixtures = fixtures.fixtures;
+            cb(fixtures);
+        });
+    }
 };
 
 Reader.prototype.readFileGlob = function(globpath, cb){

--- a/tests/fixtures/fixture1.js
+++ b/tests/fixtures/fixture1.js
@@ -1,0 +1,23 @@
+module.exports = [
+    {
+        "model":"Foo",
+        "data": {
+            "propA": "tralivali",
+            "propB": 2 + 2
+        }
+    },
+    {
+        "model":"Foo",
+        "data": {
+            "propA": "treerre",
+            "propB": 4 / 2
+        }
+    },
+    {
+        "model":"Bar",
+        "data": {
+            "propA": (new Date()).toString(),
+            "propB": 43
+        }
+    }
+];

--- a/tests/test.js
+++ b/tests/test.js
@@ -138,6 +138,42 @@ describe('fixtures', function(){
         });
     });
 
+    it('should load fixtures from js (implied relative)', function(done){
+        sf.loadFile('tests/fixtures/fixture1.js', models, function(){
+            models.Foo.count().success(function(c){
+                c.should.equal(2);
+                models.Bar.count().success(function(c){
+                    c.should.equal(1);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should load fixtures from js (explicit relative)', function(done){
+        sf.loadFile('./tests/fixtures/fixture1.js', models, function(){
+            models.Foo.count().success(function(c){
+                c.should.equal(2);
+                models.Bar.count().success(function(c){
+                    c.should.equal(1);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should load fixtures from js (absolute)', function(done){
+        sf.loadFile(process.cwd() + '/tests/fixtures/fixture1.js', models, function(){
+            models.Foo.count().success(function(c){
+                c.should.equal(2);
+                models.Bar.count().success(function(c){
+                    c.should.equal(1);
+                    done();
+                });
+            });
+        });
+    });
+
     it('should load fixtures from multiple files via glob', function(done){
         sf.loadFile('tests/fixtures/fixture*.json', models, function(){
             should.not.exist();


### PR DESCRIPTION
JS files are useful for fixtures as they allow you to define dynamic data for your records. For example, `createdAt: new Date()` or `password: bcrypt.hashSync("B4c0/\/", salt)`. Includes unit tests to verify the file path lookup works.
