### PR TITLE
Make the exported functions return Bluebird-promises and change from using Q to Bluebird internally

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var Loader = require('./lib/loader'),
-    Reader = require('./lib/reader');
+var Loader  = require('./lib/loader'),
+    Reader  = require('./lib/reader');
 
 function initopts(options){
     options = options || {};
@@ -8,46 +8,41 @@ function initopts(options){
     return options;
 }
 
-function wrap(fn){
-    return function(){
-        if(arguments.length < 2){
-            throw new error('Insufficient arguments');
+function wrap(fn) {
+    return function() {
+        if (arguments.length < 2) {
+            throw new Error('Insufficient arguments');
         } else {
             var fixtures = arguments[0], models = arguments[1], options, cb, i;
-            for(i=2;i<arguments.length;i++){
-                if(typeof arguments[i] == 'object') options = arguments[i];
-                else if (typeof arguments[i] == 'function') cb = arguments[i];
+            for(i = 2; i < arguments.length; i++) {
+                if (typeof arguments[i] === 'object') options = arguments[i];
+                else if (typeof arguments[i] === 'function') cb = arguments[i];
             }
             return fn(fixtures, models, initopts(options), cb);
         }
     };
 }
 
-
-exports.loadFixture = wrap(function (fixture, models, options, cb) {
+exports.loadFixture = wrap(function(fixture, models, options, cb) {
     var loader = new Loader(options);
-    loader.loadFixture(fixture, models, cb);
-    return loader;
+    return loader.loadFixture(fixture, models, cb);
 });
 
-exports.loadFixtures = wrap(function (fixtures, models, options, cb) {
+exports.loadFixtures = wrap(function(fixtures, models, options, cb) {
     var loader = new Loader(options);
-    loader.loadFixtures(fixtures, models,  cb);
-    return loader;
+    return loader.loadFixtures(fixtures, models,  cb);
 });
 
-exports.loadFile = wrap(function (filename, models, options, cb) {
+exports.loadFile = wrap(function(filename, models, options, cb) {
     var loader = new Loader(options), reader = new Reader(options);
-    reader.readFileGlob(filename, function(fixtures){
-        loader.loadFixtures(fixtures, models, cb);
+    return reader.readFileGlob(filename).then(function(fixtures) {
+        return loader.loadFixtures(fixtures, models, cb);
     });
-    return loader;
 });
 
-exports.loadFiles = wrap(function (filenames, models, options, cb) {
+exports.loadFiles = wrap(function(filenames, models, options, cb) {
     var loader = new Loader(options), reader = new Reader(options);
-    reader.readFiles(filenames, function(fixtures){
-        loader.loadFixtures(fixtures, models, cb);
+    return reader.readFiles(filenames).then(function(fixtures){
+        return loader.loadFixtures(fixtures, models, cb);
     });
-    return loader;
 });

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var Loader  = require('./lib/loader'),
-    Reader  = require('./lib/reader');
+var Loader = require('./lib/loader'),
+    Reader = require('./lib/reader');
 
 function initopts(options){
     options = options || {};

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,6 +1,5 @@
-var util = require('util'),
-    q = require('q');
-
+var util    = require('util'),
+    Promise = require('bluebird');
 
 var Loader = module.exports = function(options) {
     this.options = options;
@@ -43,37 +42,37 @@ Loader.prototype.loadFixture = function(fixture, models, cb) {
     if (typeof fixture != 'object') throw new Error('expected fixture to be object, is ' + (typeof fixture));
     else if (!fixture.model) throw new Error('model for a fixture is undefined');
     else if (!fixture.data) throw new Error('data undefined for fixture');
+
     var Model = models[fixture.model],
         self = this;
+
     if (!Model) {
         throw new Error('Model not found: ' + fixture.model);
     } else {
-        this.prepFixtureData(fixture.data, Model, function(data, many2many) {
+        this.prepFixtureData(fixture.data, Model).spread(function(data, many2many) {
             var setManyToMany = function(instance) {
                 //set many2many assocs if there are any
                 if (Object.keys(many2many).length) {
                     var promises = [];
                     Object.keys(many2many).forEach(function(key) {
-                        var def = q.defer();
-                        promises.push(def.promise);
                         var assoc = Model.associations[key];
-                        instance[assoc.accessors.set](many2many[key]).then(function() {
-                            def.resolve();
-                        });
+                        promises.push(instance[assoc.accessors.set](many2many[key]));
                     });
-                    q.all(promises).then(function() {
+                    Promise.all(promises).then(function() {
                         if (cb) cb();
-                    });
+                    }).catch(onError);
                 } else {
                     if (cb) cb();
                 }
-            }
+            };
+
             var where = {};
             Object.keys(Model.rawAttributes).forEach(function(k) {
                 if (data.hasOwnProperty(k)) {
                     where[k] = data[k]
                 }
             });
+
             Model.find({
                 where: where
             }).then(function(instance) {
@@ -93,13 +92,12 @@ Loader.prototype.loadFixture = function(fixture, models, cb) {
     }
 };
 
-Loader.prototype.prepFixtureData = function(data, Model, cb) {
+Loader.prototype.prepFixtureData = function(data, Model) {
     var result = {},
         promises = [],
-        errors = [],
         many2many = {};
 
-    // Allows an external caller to do some transforms to the data 
+    // Allows an external caller to do some transforms to the data
     // before it is saved
     if (this.options.transformFixtureDataFn) {
         result = this.options.transformFixtureDataFn(data, Model);
@@ -110,31 +108,27 @@ Loader.prototype.prepFixtureData = function(data, Model, cb) {
             val = data[key];
         if (assoc) {
             if (assoc.associationType == 'BelongsTo') {
-                var def = q.defer();
-                promises.push(def.promise);
-                assoc.target.find(typeof val == 'object' ? {
-                    where: val
-                } : val).then(function(obj) {
-                    result[assoc.identifier] = obj.id;
-                    def.resolve();
-                }).catch(function(err) {
-                    throw err;
-                });
+                promises.push(
+                    assoc.target.find(typeof val == 'object' ? {
+                        where: val
+                    } : val).then(function(obj) {
+                        result[assoc.identifier] = obj.id;
+                    })
+                );
             } else if (assoc.associationType == 'HasMany') {
-                many2many[assoc.associationAccessor] = [];
                 if (Array.isArray(val)) {
+                    many2many[assoc.associationAccessor] = [];
                     val.forEach(function(v) {
-                        var def = q.defer();
-                        promises.push(def.promise);
-                        assoc.target.find(typeof v == 'object' ? {
-                            where: v
-                        } : v).then(function(obj) {
-                            many2many[assoc.associationAccessor].push(obj);
-                            def.resolve();
-                        });
+                        promises.push(
+                            assoc.target.find(typeof v == 'object' ? {
+                                where: v
+                            } : v).then(function(obj) {
+                                many2many[assoc.associationAccessor].push(obj);
+                            })
+                        );
                     });
                 } else {
-                    throw new Error("HasMany associations must be arrays of where clauses");
+                    throw new Error('HasMany associations must be arrays of where clauses');
                 }
             } else {
                 throw new Error('Only BelongsTo & HasMany associations are supported');
@@ -145,7 +139,7 @@ Loader.prototype.prepFixtureData = function(data, Model, cb) {
         }
     });
 
-    q.all(promises).then(function() {
-        cb(result, many2many);
+    return Promise.all(promises).then(function() {
+        return [result, many2many];
     });
 };

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,5 +1,4 @@
-var util    = require('util'),
-    Promise = require('bluebird');
+var Promise = require('bluebird');
 
 var Loader = module.exports = function(options) {
     this.options = options;
@@ -8,27 +7,14 @@ var Loader = module.exports = function(options) {
 };
 
 Loader.prototype.loadFixtures = function(fixtures, models, cb) {
-    var i = 0,
-        self = this;
-
-    function load() {
-        if (fixtures.length > i) {
-            self.loadFixture(fixtures[i], models, function(err) {
-                if (err) throw err;
-                else {
-                    i++;
-                    load();
-                }
-            });
-        } else {
-            if (cb) cb();
-        }
-    }
-    load();
+    return Promise.each(fixtures, function(fixture) {
+        return this.loadFixture(fixture, models);
+    }.bind(this)).then(function() {
+        if (cb) cb();
+    });
 };
 
 Loader.prototype.loadFixture = function(fixture, models, cb) {
-
     var buildOptions = fixture.buildOptions,
         saveOptions = fixture.saveOptions,
         onError = function(err) {
@@ -39,7 +25,7 @@ Loader.prototype.loadFixture = function(fixture, models, cb) {
             }
         };
 
-    if (typeof fixture != 'object') throw new Error('expected fixture to be object, is ' + (typeof fixture));
+    if (typeof fixture !== 'object') throw new Error('expected fixture to be object, is ' + (typeof fixture));
     else if (!fixture.model) throw new Error('model for a fixture is undefined');
     else if (!fixture.data) throw new Error('data undefined for fixture');
 
@@ -48,48 +34,51 @@ Loader.prototype.loadFixture = function(fixture, models, cb) {
 
     if (!Model) {
         throw new Error('Model not found: ' + fixture.model);
-    } else {
-        this.prepFixtureData(fixture.data, Model).spread(function(data, many2many) {
-            var setManyToMany = function(instance) {
-                //set many2many assocs if there are any
-                if (Object.keys(many2many).length) {
-                    var promises = [];
-                    Object.keys(many2many).forEach(function(key) {
-                        var assoc = Model.associations[key];
-                        promises.push(instance[assoc.accessors.set](many2many[key]));
-                    });
-                    Promise.all(promises).then(function() {
-                        if (cb) cb();
-                    }).catch(onError);
-                } else {
-                    if (cb) cb();
-                }
-            };
+    }
 
-            var where = {};
-            Object.keys(Model.rawAttributes).forEach(function(k) {
-                if (data.hasOwnProperty(k)) {
-                    where[k] = data[k]
-                }
-            });
+    return this.prepFixtureData(fixture.data, Model).spread(function(data, many2many) {
+        var setManyToMany = function(instance) {
+            //set many2many assocs if there are any
+            var promises = [];
 
-            Model.find({
-                where: where
-            }).then(function(instance) {
-                if (instance) {
-                    self.skipped++;
-                    setManyToMany(instance);
-                } else {
-                    Model.build(data, buildOptions).save(undefined, saveOptions).then(function(instance) {
+            if (Object.keys(many2many).length) {
+                Object.keys(many2many).forEach(function(key) {
+                    var assoc = Model.associations[key];
+                    promises.push(instance[assoc.accessors.set](many2many[key]));
+                });
+            }
+
+            return Promise.all(promises);
+        };
+
+        var where = {};
+        Object.keys(Model.rawAttributes).forEach(function(k) {
+            if (data.hasOwnProperty(k)) {
+                where[k] = data[k];
+            }
+        });
+
+        return Model.find({
+            where: where
+        }).then(function(instance) {
+            if (instance) {
+                self.skipped++;
+                return setManyToMany(instance);
+            } else {
+                return Model
+                    .build(data, buildOptions)
+                    .save(undefined, saveOptions).then(function(instance) {
                         if (instance) {
                             self.saved++;
-                            setManyToMany(instance);
+                            return setManyToMany(instance);
                         }
-                    }).catch(onError)
-                }
-            }).catch(onError);
-        });
-    }
+                        return Promise.resolve();
+                    });
+            }
+        }).then(function() {
+            if (cb) cb();
+        }).catch(onError);
+    });
 };
 
 Loader.prototype.prepFixtureData = function(data, Model) {
@@ -107,20 +96,20 @@ Loader.prototype.prepFixtureData = function(data, Model) {
         var assoc = Model.associations[key],
             val = data[key];
         if (assoc) {
-            if (assoc.associationType == 'BelongsTo') {
+            if (assoc.associationType === 'BelongsTo') {
                 promises.push(
-                    assoc.target.find(typeof val == 'object' ? {
+                    assoc.target.find(typeof val === 'object' ? {
                         where: val
                     } : val).then(function(obj) {
                         result[assoc.identifier] = obj.id;
                     })
                 );
-            } else if (assoc.associationType == 'HasMany') {
+            } else if (assoc.associationType === 'HasMany') {
                 if (Array.isArray(val)) {
                     many2many[assoc.associationAccessor] = [];
                     val.forEach(function(v) {
                         promises.push(
-                            assoc.target.find(typeof v == 'object' ? {
+                            assoc.target.find(typeof v === 'object' ? {
                                 where: v
                             } : v).then(function(obj) {
                                 many2many[assoc.associationAccessor].push(obj);

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -64,17 +64,16 @@ Loader.prototype.loadFixture = function(fixture, models, cb) {
             if (instance) {
                 self.skipped++;
                 return setManyToMany(instance);
-            } else {
-                return Model
-                    .build(data, buildOptions)
-                    .save(undefined, saveOptions).then(function(instance) {
-                        if (instance) {
-                            self.saved++;
-                            return setManyToMany(instance);
-                        }
-                        return Promise.resolve();
-                    });
             }
+
+            return Model
+                .build(data, buildOptions)
+                .save(saveOptions).then(function(instance) {
+                    if (instance) {
+                        self.saved++;
+                        return setManyToMany(instance);
+                    }
+                });
         }).then(function() {
             if (cb) cb();
         }).catch(onError);

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -1,7 +1,8 @@
-var glob = require('glob'),
-    path = require('path'),
-    yaml = require('js-yaml'),
-    fs = require('fs');
+var Promise = require('bluebird'),
+    path    = require('path'),
+    yaml    = require('js-yaml'),
+    glob    = Promise.promisify(require('glob')),
+    fs      = Promise.promisifyAll(require('fs'));
 
 var Reader = module.exports = function (options) {
     options.encoding = options.encoding || 'utf8';
@@ -14,56 +15,44 @@ var PARSERS = Reader.PARSERS = {
     '.yaml': yaml.safeLoad
 };
 
-Reader.prototype.readFile = function(filename, cb){
-    this.options.log('Fixtures: reading file '+filename+'...');
+Reader.prototype.readFile = Promise.method(function(filename) {
+    this.options.log('Fixtures: reading file ' + filename + '...');
     var ext = path.extname(filename).toLowerCase();
-    if(ext === '.js') {
-        cb(require(path.resolve(process.cwd(), filename)));
-    }
-    else {
-        if(!PARSERS[ext]) {
+
+    if (ext === '.js') {
+        return require(path.resolve(process.cwd(), filename));
+    } else {
+        if (!PARSERS[ext]) {
             throw new Error('unknown file type: ', ext);
         }
-        fs.readFile(filename, this.options.encoding, function(err, data){
-            if(err) throw err;
+        return fs.readFileAsync(filename, this.options.encoding).then(function(data) {
             var fixtures = PARSERS[ext](data);
-            if(fixtures.fixtures) fixtures = fixtures.fixtures;
-            cb(fixtures);
+            if (fixtures.fixtures) fixtures = fixtures.fixtures;
+            return fixtures;
         });
     }
-};
+});
 
-Reader.prototype.readFileGlob = function(globpath, cb){
+Reader.prototype.readFileGlob = function(globpath){
     var self = this, result = [];
-    glob(globpath, function(err, filenames){
-        if(err) throw err;
-        else {
-            var read = function(){
-                if(filenames.length){
-                    self.readFile(filenames.shift(), function(res){
-                        result = result.concat(res);
-                        read();
-                    });
-                } else {
-                    cb(result);
-                }
-            };
-            read();
-        }
+    return glob(globpath).then(function(filenames) {
+        return Promise.each(filenames, function(filename) {
+            return self.readFile(filename).then(function(res) {
+                result = result.concat(res);
+            });
+        }).then(function() {
+            return result;
+        });
     });
 };
 
-Reader.prototype.readFiles = function(filenames, cb){
-    var queue = filenames.slice(0), result = [], self = this;
-    function read(){
-        if(queue.length) {
-            self.readFileGlob(queue.shift(), function(res){
-                result = result.concat(res);
-                read();
-            });
-        } else {
-            cb(result);
-        }
-    }
-    read();
+Reader.prototype.readFiles = function(filenames){
+    var self = this, result = [];
+    return Promise.each(filenames, function(filename) {
+        return self.readFileGlob(filename).then(function(res) {
+            result = result.concat(res);
+        });
+    }).then(function() {
+        return result;
+    });
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "sequelize fixture loader",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha tests/test.js"
+    "test": "./node_modules/.bin/mocha tests"
   },
   "engines": {
     "node": "*"
@@ -14,9 +14,9 @@
     "fixtures"
   ],
   "dependencies": {
-    "js-yaml": "~2.1.0",
+    "bluebird": "^2.4.2",
     "glob": "~3.2.1",
-    "q": "~0.9.6"
+    "js-yaml": "~2.1.0"
   },
   "devDependencies": {
     "sequelize-sqlite": "*",

--- a/tests/test-callbacks.js
+++ b/tests/test-callbacks.js
@@ -2,11 +2,9 @@ var sf = require('../index'),
     should = require('should'),
     models = require('./models');
 
-beforeEach(function(done){
-    models.sequelize.drop().then(function(){
-        models.sequelize.sync().then(function(){
-            done();
-        });
+beforeEach(function() {
+    return models.sequelize.drop().then(function(){
+        models.sequelize.sync();
     });
 });
 
@@ -18,7 +16,7 @@ var FOO_FIXTURE = {
     }
 };
 
-describe('fixtures', function(){
+describe('fixtures (with callbacks)', function(){
     it('should load fixture without id', function(done){
         sf.loadFixture(FOO_FIXTURE, models, function (){
             models.Foo.find({
@@ -54,7 +52,7 @@ describe('fixtures', function(){
         });
     });
 
-    it('sould accept buildOptions in fixture', function(done){
+    it('should accept buildOptions in fixture', function(done){
         sf.loadFixture({
             model: 'Article',
             buildOptions: { raw: true, isNewRecord: true },
@@ -74,7 +72,7 @@ describe('fixtures', function(){
         });
     });
 
-    it('sould accept saveOptions in fixture', function(done){
+    it('should accept saveOptions in fixture', function(done){
         sf.loadFixture({
             model: 'Article',
             saveOptions: { fields: ['title', 'body'] },

--- a/tests/test-promises.js
+++ b/tests/test-promises.js
@@ -1,0 +1,341 @@
+var sf     = require('../index'),
+    should = require('should'),
+    models = require('./models');
+
+beforeEach(function(){
+    return models.sequelize.drop().then(function() {
+        return models.sequelize.sync();
+    });
+});
+
+var FOO_FIXTURE = {
+    model: 'Foo',
+    data: {
+        propA: 'bar',
+        propB: 1
+    }
+};
+
+describe('fixture (with promises)', function() {
+    it('should load fixture without id', function() {
+        return sf.loadFixture(FOO_FIXTURE, models)
+            .then(function() {
+                return models.Foo.find({
+                    where: {
+                        propA: 'bar',
+                        propB: 1
+                    }
+                });
+            }).then(function(foo){
+                should.exist(foo);
+                foo.propA.should.equal('bar');
+                foo.propB.should.equal(1);
+            });
+    });
+
+    it('should load fixture with id', function() {
+        return sf.loadFixture({
+            model: 'Foo',
+            data: {
+                id: 3,
+                propA: 'bar',
+                propB: 1
+            }
+        }, models).then(function() {
+            return models.Foo.find(3);
+        }).then(function(foo){
+            should.exist(foo);
+            foo.propA.should.equal('bar');
+            foo.propB.should.equal(1);
+        });
+    });
+
+    it('should accept buildOptions in fixture', function() {
+        return sf.loadFixture({
+            model: 'Article',
+            buildOptions: { raw: true, isNewRecord: true },
+            data: {
+                title: 'Any title',
+                slug: 'My Invalid Slug'
+            }
+        }, models).then(function() {
+            return models.Article.find({
+                where: {
+                    title: 'Any title'
+                }
+            });
+        }).then(function(data) {
+            data.slug.should.equal('My Invalid Slug');
+        });
+    });
+
+    it('should accept saveOptions in fixture', function() {
+        return sf.loadFixture({
+            model: 'Article',
+            saveOptions: { fields: ['title', 'body'] },
+            data: {
+                title: 'Any title',
+                slug: 'my-slug',
+                body: 'My nice article'
+            }
+        }, models).then(function() {
+            return models.Article.find({
+                where: {
+                    title: 'Any title'
+                }
+            });
+        }).then(function(data) {
+            (data.slug === null).should.equal(true);
+        });
+    });
+
+    it('should not duplicate fixtures', function () {
+        return sf.loadFixture(FOO_FIXTURE, models)
+            .then(function() {
+                return sf.loadFixture(FOO_FIXTURE, models);
+            }).then(function() {
+                return models.Foo.count({
+                    where: {
+                        propA: 'bar'
+                    }
+                });
+            }).then(function(c) {
+                c.should.equal(1);
+            });
+    });
+
+    it('should load multiple fixtures', function() {
+        return sf.loadFixtures([FOO_FIXTURE, {
+            model: 'Foo',
+            data: {
+                propA: 'baz',
+                propB: 2
+            }
+        }], models).then(function() {
+            return models.Foo.count();
+        }).then(function(c){
+            c.should.equal(2);
+        });
+    });
+
+    it('should load fixtures from json', function() {
+        return sf.loadFile('tests/fixtures/fixture1.json', models)
+            .then(function() {
+                return models.Foo.count();
+            }).then(function(c){
+                c.should.equal(2);
+                return models.Bar.count();
+            }).then(function(c){
+                c.should.equal(1);
+            });
+    });
+
+    it('should load fixtures from js (implied relative)', function() {
+        return sf.loadFile('tests/fixtures/fixture1.js', models)
+            .then(function() {
+                return models.Foo.count();
+            }).then(function(c) {
+                c.should.equal(2);
+                return models.Bar.count();
+            }).then(function(c) {
+                c.should.equal(1);
+            });
+    });
+
+    it('should load fixtures from js (explicit relative)', function() {
+        return sf.loadFile('./tests/fixtures/fixture1.js', models)
+            .then(function() {
+                return models.Foo.count();
+            }).then(function(c) {
+                c.should.equal(2);
+                return models.Bar.count();
+            }).then(function(c) {
+                c.should.equal(1);
+            });
+    });
+
+    it('should load fixtures from js (absolute)', function() {
+        return sf.loadFile(process.cwd() + '/tests/fixtures/fixture1.js', models)
+            .then(function() {
+                return models.Foo.count();
+            }).then(function(c){
+                c.should.equal(2);
+                return models.Bar.count();
+            }).then(function(c){
+                c.should.equal(1);
+            });
+    });
+
+    it('should load fixtures from multiple files via glob', function() {
+        return sf.loadFile('tests/fixtures/fixture*.json', models)
+            .then(function() {
+                return models.Foo.count();
+            }).then(function(c){
+                c.should.equal(3);
+                return models.Bar.count();
+            }).then(function(c) {
+                c.should.equal(1);
+            });
+    });
+
+    it('should load fixtures from multiple files', function() {
+        return sf.loadFiles(['tests/fixtures/fixture1.json', 'tests/fixtures/fixture2.json'], models)
+            .then(function() {
+                return models.Foo.count();
+            }).then(function(c) {
+                c.should.equal(3);
+                return models.Bar.count();
+            }).then(function(c) {
+                c.should.equal(1);
+            });
+    });
+
+    it('should load yaml fixtures', function() {
+        return sf.loadFile('tests/fixtures/fixture3.yaml', models)
+            .then(function() {
+                return models.Foo.count();
+            }).then(function(c) {
+                c.should.equal(1);
+                return models.Bar.count();
+            }).then(function(c) {
+                c.should.equal(1);
+            });
+    });
+
+    it('should load assosication with. natural keys', function() {
+        return sf.loadFile('tests/fixtures/natkeys.yaml', models)
+            .then(function() {
+                return models.Foo.findAll();
+            }).then(function(foos){
+                foos.length.should.equal(1);
+                return foos[0].getBar();
+            }).then(function(bar) {
+                bar.propA.should.equal('baz');
+                bar.propB.should.equal(1);
+            });
+    });
+
+    it('should load assosication with. ids', function() {
+        return sf.loadFile('tests/fixtures/associd.yaml', models)
+            .then(function() {
+                return models.Foo.findAll();
+            }).then(function(foos) {
+                foos.length.should.equal(1);
+                foos[0].id.should.equal(303);
+                return foos[0].getBar();
+            }).then(function(bar) {
+                bar.id.should.equal(202);
+                bar.propA.should.equal('bb');
+            });
+    });
+
+    it('should load many2many assocs by nat keys', function() {
+        return sf.loadFile('tests/fixtures/many2manynatural.yaml', models)
+            .then(function() {
+                return models.Project.find({
+                    where: {
+                        name: 'Great Project'
+                    }
+                });
+            }).then(function(project) {
+                return project.getPeople();
+            }).then(function(persons) {
+                persons.length.should.equal(2);
+                var foundfirst = false;
+                var foundsecond = false;
+
+                persons.forEach(function(dude) {
+                    if (dude.name === 'John') {
+                        foundfirst = true;
+                    }
+                    if (dude.name === 'Jack') {
+                        foundsecond = true;
+                    }
+                });
+                foundfirst.should.equal(true);
+                foundsecond.should.equal(true);
+            });
+    });
+
+    it('empty many2many should not break', function() {
+        return sf.loadFile('tests/fixtures/many2manynatural.yaml', models)
+            .then(function() {
+                return models.Project.find({
+                    where: {
+                        name: 'Bad Project'
+                    }
+                });
+            }).then(function(project) {
+                return project.getPeople();
+            }).then(function(persons) {
+                persons.length.should.equal(0);
+            });
+    });
+
+    it('should load many2many assocs by ids', function() {
+        return sf.loadFile('tests/fixtures/many2manyid.yaml', models)
+            .then(function() {
+                return models.Project.find({
+                    where: {
+                        name: 'Stoopid Project'
+                    }
+                });
+            }).then(function(project) {
+                return project.getPeople();
+            }).then(function(persons) {
+                persons.length.should.equal(2);
+                var foundfirst = false;
+                var foundsecond = false;
+                persons.forEach(function(dude){
+                    if(dude.name === 'Prim') {
+                        foundfirst = true;
+                    }
+                    if(dude.name === 'Selena') {
+                        foundsecond = true;
+                    }
+                });
+                foundfirst.should.equal(true);
+                foundsecond.should.equal(true);
+            });
+    });
+
+    it('should set many2many even if object already exists', function() {
+        return sf.loadFile('tests/fixtures/many2manynatural.yaml', models)
+            .then(function() {
+                return models.Project.find({
+                    where: {
+                        name: 'Bad Project'
+                    }
+                });
+            }).then(function(project) {
+                return project.getPeople();
+            }).then(function(persons) {
+                persons.length.should.equal(0);
+                return sf.loadFixture({
+                    model: 'Project',
+                    data: {
+                        name: 'Bad Project',
+                        peopleprojects: [
+                            {
+                                name: 'John'
+                            },
+                            {
+                                name: 'Jack'
+                            }
+                        ]
+                    }
+                }, models);
+            }).then(function() {
+                return models.Project.findAll({
+                    where: {
+                        name: 'Bad Project'
+                    }
+                });
+            }).then(function(projects){
+                projects.length.should.equal(1);
+                return projects[0].getPeople();
+            }).then(function(persons){
+                persons.length.should.equal(2);
+            });
+    });
+});


### PR DESCRIPTION
As all the Sequelize functions themself work with Bluebird-promises it'd be nice if this library did too.
I thought you might not want to remove callbacks right away, so at the moment the functions will both take a callback and return a Bluebird-promise. Because of this I've added a duplicate set of tests that work with promises instead of callbacks.

I also changed from using Q internally to Bluebird and refactored a few things. 

Note that this means that the exported functions will return a Promise instead of loader.

EDIT: Fixes #23.