### PR TITLE
added support for a `keys` list of columns to use when checking for dupes

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -53,7 +53,9 @@ Loader.prototype.loadFixture = function(fixture, models, cb) {
 
         var where = {};
         Object.keys(Model.rawAttributes).forEach(function(k) {
-            if (data.hasOwnProperty(k)) {
+            if (data.hasOwnProperty(k) && (!fixture.keys || !fixture.keys.length)) {
+                where[k] = data[k];
+            } else if (data.hasOwnProperty(k) && fixture.keys && fixture.keys.length && fixture.keys.indexOf(k) > -1) {
                 where[k] = data[k];
             }
         });

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -53,9 +53,9 @@ Loader.prototype.loadFixture = function(fixture, models, cb) {
 
         var where = {};
         Object.keys(Model.rawAttributes).forEach(function(k) {
-            if (data.hasOwnProperty(k) && (!fixture.keys || !fixture.keys.length)) {
-                where[k] = data[k];
-            } else if (data.hasOwnProperty(k) && fixture.keys && fixture.keys.length && fixture.keys.indexOf(k) > -1) {
+            if (data.hasOwnProperty(k) &&
+                ((!fixture.keys || !fixture.keys.length) ||
+                (fixture.keys && fixture.keys.length && fixture.keys.indexOf(k) > -1))) {
                 where[k] = data[k];
             }
         });

--- a/tests/test-callbacks.js
+++ b/tests/test-callbacks.js
@@ -124,6 +124,27 @@ describe('fixtures (with callbacks)', function(){
         });
     });
 
+    it('should not load duplicate fixtures whose keys already exist', function(done) {
+        sf.loadFixtures([FOO_FIXTURE, {
+            model: 'Foo',
+            keys: ['propA'],
+            data: {
+                propA: 'baz',
+                propB: 2
+            }
+        }], models, function (err){
+            should.not.exist(err);
+            models.Foo.count({
+                where: {
+                    propA: 'bar'
+                }
+            }).then(function(c){
+                c.should.equal(1);
+                done();
+            });
+        });
+    });
+
     it('should load fixtures from json', function(done){
         sf.loadFile('tests/fixtures/fixture1.json', models, function(){
             models.Foo.count().then(function(c){

--- a/tests/test-promises.js
+++ b/tests/test-promises.js
@@ -118,6 +118,25 @@ describe('fixture (with promises)', function() {
         });
     });
 
+    it('should not duplicate fixtures whose keys already exist', function() {
+        return sf.loadFixtures([FOO_FIXTURE, {
+            model: 'Foo',
+            keys: ['propA'],
+            data: {
+                propA: 'bar',
+                propB: 2
+            }
+        }], models).then(function() {
+            return models.Foo.count({
+                where: {
+                    propA: 'bar'
+                }
+            });
+        }).then(function(c){
+            c.should.equal(1);
+        });
+    });
+
     it('should load fixtures from json', function() {
         return sf.loadFile('tests/fixtures/fixture1.json', models)
             .then(function() {


### PR DESCRIPTION
There may be some cases where you may wish to not insert a row when only specific columns have changed rather than all the columns for a row being identical when checking to see if a row exists the in DB. I've added a new `keys` property that is an array of columns that are the primary keys for the row. This is good in scenarios where your DB uses a dynamic value for a particular column.

