### PR TITLE
Made sequelize-fixtures compatible with Sequelize 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,42 @@ OR
 ]
 ```
 
+If using Sequelize 3.0.0 or later, you can define the associated resources by their name instead of the relation name, like this:
+
+```json
+[
+    {
+        "model":"Person",
+        "data":{
+            "name": "Jack",
+            "role": "Developer"
+        }
+    },
+    {
+        "model":"Person",
+        "data":{
+            "name": "John",
+            "role": "Analyst"
+        }
+    },
+    {
+        "model":"Project",
+        "data": {
+            "name": "The Great Project",
+            "people": [
+                {                        
+                    "name": "Jack"
+                },
+                {
+                    "name": "John"
+                }
+            ]
+        }
+    }
+
+]
+```
+
 #### Build options, save optons
 
 For each model you can provide build options that are passed to Model.build() and save options that are passed to instance.save(), example:

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -92,7 +92,12 @@ Loader.prototype.prepFixtureData = function(data, Model) {
     }
 
     Object.keys(data).forEach(function(key) {
-        var assoc = Model.associations[key],
+        var foundInThroughName = null;
+        // For Sequelize < 3.0.0 compatibility (using for instance "actorsmovies" instead of "actors" or "movies")
+        Object.keys(Model.associations).forEach(function(assoc_name) {
+            if(Model.associations[assoc_name].options && Model.associations[assoc_name].options.through == key) return foundInThroughName = assoc_name;
+        });
+        var assoc = Model.associations[foundInThroughName || key],
             val = data[key];
         if (assoc) {
             if (assoc.associationType === 'BelongsTo') {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -99,7 +99,7 @@ Loader.prototype.prepFixtureData = function(data, Model) {
                 promises.push(
                     assoc.target.find(typeof val === 'object' ? {
                         where: val
-                    } : val).then(function(obj) {
+                    } : {where: {id: val}}).then(function(obj) {
                         result[assoc.identifier] = obj.id;
                     })
                 );
@@ -110,7 +110,7 @@ Loader.prototype.prepFixtureData = function(data, Model) {
                         promises.push(
                             assoc.target.find(typeof v === 'object' ? {
                                 where: v
-                            } : v).then(function(obj) {
+                            } : {where: {id: v}}).then(function(obj) {
                                 many2many[assoc.associationAccessor].push(obj);
                             })
                         );

--- a/tests/models/index.js
+++ b/tests/models/index.js
@@ -17,7 +17,7 @@ exports.all = [];
     m.Foo.belongsTo(m.Bar);
     // From Sequelize 3.0.0 changelog:
     // "[REMOVED] N:M relationships can no longer be represented by 2 x hasMany" 
-    // Settings constraints to false to keep this working
+    // Setting constraints to false to keep this working
     m.Project.hasMany(m.Person, {constraints: false});
     m.Person.hasMany(m.Project, {constraints: false});
     m.Actor.belongsToMany(m.Movie, {through: 'actorsmovies'});

--- a/tests/models/index.js
+++ b/tests/models/index.js
@@ -15,8 +15,11 @@ exports.all = [];
 
 (function (m) {
     m.Foo.belongsTo(m.Bar);
-    m.Project.hasMany(m.Person);
-    m.Person.hasMany(m.Project);
-    m.Actor.belongsToMany(m.Movie);
-    m.Movie.belongsToMany(m.Actor);
+    // From Sequelize 3.0.0 changelog:
+    // "[REMOVED] N:M relationships can no longer be represented by 2 x hasMany" 
+    // Settings constraints to false to keep this working
+    m.Project.hasMany(m.Person, {constraints: false});
+    m.Person.hasMany(m.Project, {constraints: false});
+    m.Actor.belongsToMany(m.Movie, {through: 'actorsmovies'});
+    m.Movie.belongsToMany(m.Actor, {through: 'actorsmovies'});
 })(exports);

--- a/tests/test-callbacks.js
+++ b/tests/test-callbacks.js
@@ -43,7 +43,7 @@ describe('fixtures (with callbacks)', function(){
             }
         }, models, function (err){
             should.not.exist(err);
-            models.Foo.find(3).then(function(foo){
+            models.Foo.find({where: {id: 3}}).then(function(foo){
                 should.exist(foo);
                 foo.propA.should.equal('bar');
                 foo.propB.should.equal(1);

--- a/tests/test-promises.js
+++ b/tests/test-promises.js
@@ -42,7 +42,7 @@ describe('fixture (with promises)', function() {
                 propB: 1
             }
         }, models).then(function() {
-            return models.Foo.find(3);
+            return models.Foo.find({where: {id: 3}});
         }).then(function(foo){
             should.exist(foo);
             foo.propA.should.equal('bar');


### PR DESCRIPTION
- Tests are all passing, both with Sequelize 2.x or 3.0.0
- Added a way to define an association only by the associated resource name instead of the association name (should be the preferred way of doing it IMO)

I used methods compatible with 2.x, but a cleaner way of doing it would be to fully conform to Sequelize 3.0.0 and use new standards (like `findById` or not using 2x `hasMany`)