### PR TITLE
Adding ability to skip model attributes on lookup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,22 @@ In case you want to detect duplicates based on specific field or fields rather t
 ```
 In this example only John will be loaded
 
+#### Skipping lookup fields
+
+By default, all fields are used to determine if the given fixture should be inserted. This behavior can be modified by using the `skipLookup` data attribute to exclude certain fields.
+
+```json
+{
+    "model": "Person",
+    "skipLookup": ["name"],
+    "data": {
+        "name": "John",
+        "email": "example@example.com",
+    }
+}
+```
+
+In the above example, only the `email` field will be used.
 
 # grunt task
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -51,7 +51,7 @@ Loader.prototype.loadFixture = function(fixture, models) {
 
         var where = {};
         Object.keys(Model.rawAttributes).forEach(function(k) {
-            if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1) && !(fixture.skipSearch !== undefined && fixture.skipSearch[k])) {
+            if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1) && (fixture.skipLookup === undefined || fixture.skipLookup.indexOf(k) === -1)) {
                 where[k] = data[k];
             }
         });

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -51,7 +51,7 @@ Loader.prototype.loadFixture = function(fixture, models) {
 
         var where = {};
         Object.keys(Model.rawAttributes).forEach(function(k) {
-            if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1)) {
+            if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1) && !(fixture.skipSearch !== undefined && fixture.skipSearch[k])) {
                 where[k] = data[k];
             }
         });


### PR DESCRIPTION
There are cases where I don't want to use one or more attributes to determine if the record should be inserted or not. This small change allows me to control that by adding the `skipLookup` attribute to the fixture structure.