### PR TITLE
Create the associated model of fixture if it doesn't exist.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -124,7 +124,11 @@ Loader.prototype.prepFixtureData = function(data, Model) {
                 promises.push(
                     (typeof val === 'object' ?  assoc.target.find(options) : assoc.target.findOne(options))
                     .then(function(obj) {
-                        result[assoc.identifier] = obj[assoc.target.primaryKeyField || 'id'];
+                        if (obj) {
+                            result[assoc.identifier] = obj[assoc.target.primaryKeyField || 'id'];
+                        } else {
+                            result[assoc.options.name.singular] = val;
+                        }
                         return Promise.resolve();
                     })
                 );

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -121,6 +121,31 @@ describe('fixture (with promises)', function() {
         });
     });
 
+    it('should load a fixture and create associated fixture', function() {
+        return sf.loadFixtures([{
+            model: 'Foo',
+            data: {
+                propA: 'baz',
+                propB: 2,
+                bar: {
+                    propA: 'barPropA',
+                    propB: 'barPropB'
+                }
+            },
+            buildOptions: {
+                include: [models.Bar]
+            }
+        }], models).then(function() {
+            return models.Foo.count();
+        }).then(function(c){
+            c.should.equal(1);
+
+            return models.Bar.count();
+        }).then(function(c){
+            c.should.equal(1);
+        });
+    });
+
     it('should not duplicate fixtures whose keys already exist', function() {
         return sf.loadFixtures([FOO_FIXTURE, {
             model: 'Foo',


### PR DESCRIPTION
* Sequelize supports creating of associated models in one step. See:
  docs.sequelizejs.com/en/latest/docs/associations/#creating-with-associations
* If the associated model of a fixture doesn't exist in the database
  yet, pass along the data of the associated model so that it's included
  in `Model.build` and ends up getting created.