### PR TITLE
add modifyFixtureDataFn method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Tested with latest Sequelize (3.0.0), should work on 2.x.
         doStuffAfterLoad();
     });
 
+    //modify each model being loaded
+    sequelize_fixtures.loadFile('fixtures/*.json', models, {
+        modifyFixtureDataFn: function (data) {
+          if(!data.createdAt) {
+            data.createdAt = new Date();
+          }
+          return data;
+        }
+    }).then(function() {
+        doStuffAfterLoad();
+    });
+
     //from array
     var fixtures = [
         {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -94,6 +94,12 @@ Loader.prototype.prepFixtureData = function(data, Model) {
         result = {},
         promises = [],
         many2many = {};
+    
+    // Allows an external caller to modify the data
+    // before it is evaluated
+    if (this.options.modifyFixtureDataFn) {
+        data = this.options.modifyFixtureDataFn(data, Model);
+    }
 
     // Allows an external caller to do some transforms to the data
     // before it is saved

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -510,4 +510,40 @@ describe('fixture (with promises)', function() {
             foundsecond.should.equal(true);
         }).then(done);
     });
+
+    it('should load fixtures and then transform their values', function() {
+        return sf.loadFile('tests/fixtures/fixture1.json', models, { 
+            transformFixtureDataFn: function (data, model) {
+                if (model.name === 'bar') {
+                  data.propB = 99; 
+                }
+                return data;
+            }
+        }).then(function() {
+            return models.Bar.findAll();
+        }).then(function(bars){
+            bars.forEach(function(bar) {
+              bar.propB.should.equal(99);
+            });
+        });
+    });
+
+    it('should load user modified fixtures', function() {
+        return sf.loadFile('tests/fixtures/fixture1.json', models, { 
+            modifyFixtureDataFn: function (data, model) {
+                if (model.name === 'foo') {
+                  delete data.propB;
+                  data.status = true; 
+                }
+                return data;
+            }
+        }).then(function() {
+            return models.Foo.findAll();
+        }).then(function(foos){
+            foos.forEach(function(foo) {
+              (foo.propB === null).should.equal(true);
+              foo.status.should.equal(true);
+            });
+        });
+    });
 });


### PR DESCRIPTION
- update README.md

This external caller is meant to do some major modification on the data processed.

A practical use case of this method can occur when the fixture loaded contains many fields unnecessary or with a structure radically different from the model.

I preferred to avoid to modify the behavior of `transformFixtureDataFn` to ensure retro-compatibility.