### PR TITLE
Allows to add additional attributes to many2many associations.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -45,8 +45,6 @@ Loader.prototype.loadFixture = function(fixture, models) {
                 Object.keys(many2many).forEach(function(key) {
                     var assoc = Model.associations[key];
 
-                    console.log('Setting many2many' + many2many[key]);
-
                     if(many2many[key][0] && many2many[key][0].entity) {
 
                         var i = 0;
@@ -167,29 +165,21 @@ Loader.prototype.prepFixtureData = function(data, Model) {
                         if(typeof v !== 'object') {
                             where[assoc.target.primaryKeyField] = v;
                             var options = typeof v === 'object' ? { where: v } : { where: where };
-
-                            console.log('Default pkey: ' + JSON.stringify(where));
                             options = {where : where};
                         } else if(v.entity && typeof v.entity !== 'object') {
 
                             where[assoc.target.primaryKeyField] = v.entity;
                             var options = typeof v === 'object' ? { where: v } : { where: where };
-
-                            console.log('Custom pkey: ' + JSON.stringify(where));
                             options = {where : where};
                         } else if(v.entity && typeof v.entity === 'object') {
 
                             where[assoc.target.primaryKeyField] = v.entity;
                             var options = typeof v === 'object' ? { where: v } : { where: where };
-
-                            console.log('Custom object: ' + JSON.stringify(where));
                             options = {where :  v.entity};
                         } else {
 
                             where[assoc.target.primaryKeyField] = v;
                             var options = typeof v === 'object' ? { where: v } : { where: where };
-
-                            console.log('Default object: ' + JSON.stringify(where));
                             options = { where: v};
                         }
 
@@ -197,25 +187,21 @@ Loader.prototype.prepFixtureData = function(data, Model) {
                             options.transaction = self.options.transaction;
 
                         if(typeof v !== 'object') {
-                            console.log('Default find by pkey: ' + JSON.stringify(options));
                             promises.push(assoc.target.findOne(options).then(function(obj) {
                                 many2many[assoc.associationAccessor].push(obj);
                                 return Promise.resolve();
                             }));
                         } else if(v.entity && typeof v.entity !== 'object') {
-                            console.log('Custom find by pkey: ' + JSON.stringify(options));
                             promises.push(assoc.target.findOne(options).then(function(obj) {
                                 many2many[assoc.associationAccessor].push({entity: obj, options: v.options});
                                 return Promise.resolve();
                             }));
                         } else if(v.entity && typeof v.entity === 'object') {
-                            console.log('Default find by object: ' + JSON.stringify(options));
                             promises.push(assoc.target.find(options).then(function(obj) {
                                 many2many[assoc.associationAccessor].push({entity: obj, options: v.options});
                                 return Promise.resolve();
                             }));
                         } else {
-                            console.log('Custom find by pkey: ' + JSON.stringify(options));
                             promises.push(assoc.target.find(options).then(function(obj) {
                                 many2many[assoc.associationAccessor].push(obj);
                                 return Promise.resolve();

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -44,8 +44,24 @@ Loader.prototype.loadFixture = function(fixture, models) {
             if (Object.keys(many2many).length) {
                 Object.keys(many2many).forEach(function(key) {
                     var assoc = Model.associations[key];
-                    var options = self.options.transaction ? {transaction: self.options.transaction} : {};
-                    promises.push(instance[assoc.accessors.set](many2many[key], options));
+
+                    console.log('Setting many2many' + many2many[key]);
+
+                    if(many2many[key][0].entity) {
+
+                        var i = 0;
+                        for(i = 0; i < many2many[key].length; i += 1) {
+                            var options = many2many[key][i].options ? many2many[key][i].options : {};
+                            if(self.options.transaction) {
+                                options.transaction = self.options.transaction;
+                            }
+
+                            promises.push(instance[assoc.accessors.add](many2many[key][i].entity, options));
+                        }
+                    } else {
+                        var options = self.options.transaction ? {transaction: self.options.transaction} : {};
+                        promises.push(instance[assoc.accessors.set](many2many[key], options));
+                    }
                 });
             }
 
@@ -147,17 +163,72 @@ Loader.prototype.prepFixtureData = function(data, Model) {
                     many2many[assoc.associationAccessor] = [];
                     val.forEach(function(v) {
                         var where = {};
-                        where[assoc.target.primaryKeyField] = v;
-                        var options = typeof v === 'object' ? { where: v } : { where: where };
+
+                        if(typeof v !== 'object') {
+                            where[assoc.target.primaryKeyField] = v;
+                            var options = typeof v === 'object' ? { where: v } : { where: where };
+
+                            console.log('Default pkey: ' + JSON.stringify(where));
+                            options = {where : where};
+                        } else if(v.entity && typeof v.entity !== 'object') {
+
+                            where[assoc.target.primaryKeyField] = v.entity;
+                            var options = typeof v === 'object' ? { where: v } : { where: where };
+
+                            console.log('Custom pkey: ' + JSON.stringify(where));
+                            options = {where : where};
+                        } else if(v.entity && typeof v.entity === 'object') {
+
+                            where[assoc.target.primaryKeyField] = v.entity;
+                            var options = typeof v === 'object' ? { where: v } : { where: where };
+
+                            console.log('Custom object: ' + JSON.stringify(where));
+                            options = {where :  v.entity};
+                        } else {
+
+                            where[assoc.target.primaryKeyField] = v;
+                            var options = typeof v === 'object' ? { where: v } : { where: where };
+
+                            console.log('Default object: ' + JSON.stringify(where));
+                            options = { where: v};
+                        }
+
                         if (self.options.transaction)
                             options.transaction = self.options.transaction;
-                        promises.push(
-                            (typeof v === 'object' ?  assoc.target.find(options) : assoc.target.findOne(options))
-                            .then(function(obj) {
+
+                        if(typeof v !== 'object') {
+                            console.log('Default find by pkey: ' + JSON.stringify(options));
+                            promises.push(assoc.target.findOne(options).then(function(obj) {
                                 many2many[assoc.associationAccessor].push(obj);
                                 return Promise.resolve();
-                            })
-                        );
+                            }));
+                        } else if(v.entity && typeof v.entity !== 'object') {
+                            console.log('Custom find by pkey: ' + JSON.stringify(options));
+                            promises.push(assoc.target.findOne(options).then(function(obj) {
+                                many2many[assoc.associationAccessor].push({entity: obj, options: v.options});
+                                return Promise.resolve();
+                            }));
+                        } else if(v.entity && typeof v.entity === 'object') {
+                            console.log('Default find by object: ' + JSON.stringify(options));
+                            promises.push(assoc.target.find(options).then(function(obj) {
+                                many2many[assoc.associationAccessor].push({entity: obj, options: v.options});
+                                return Promise.resolve();
+                            }));
+                        } else {
+                            console.log('Custom find by pkey: ' + JSON.stringify(options));
+                            promises.push(assoc.target.find(options).then(function(obj) {
+                                many2many[assoc.associationAccessor].push(obj);
+                                return Promise.resolve();
+                            }));
+                        }
+
+                        //promises.push(
+                        //    (typeof v === 'object' ?  assoc.target.find(options) : assoc.target.findOne(options))
+                        //    .then(function(obj) {
+                        //        many2many[assoc.associationAccessor].push(obj);
+                        //        return Promise.resolve();
+                        //    })
+                        //);
                     });
                 } else {
                     throw new Error('HasMany associations must be arrays of where clauses');

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -47,7 +47,7 @@ Loader.prototype.loadFixture = function(fixture, models) {
 
                     console.log('Setting many2many' + many2many[key]);
 
-                    if(many2many[key][0].entity) {
+                    if(many2many[key][0] && many2many[key][0].entity) {
 
                         var i = 0;
                         for(i = 0; i < many2many[key].length; i += 1) {


### PR DESCRIPTION
The current implementations like described in https://github.com/domasx2/sequelize-fixtures#many-to-many still work as expected. In addition, relations with additional attributes can be defined as follows:

{
        "model":"Project",
        "data": {
            "id": 20,
            "name": "The Great Project",
            "people": [{"entity": 122, "options": {"role":"manager"}}, {"entity":123, "options": {"role":"developer"}}]
        }
    }

or

{
        "model":"Project",
        "data": {
            "name": "The Great Project",
            "people": [ {
                   "entity":  {
                       "name": "Jack"
                   },
                   "options": {
                       "role": "manager"
                   }
                }
            ]
        }
    }