### PR TITLE
Don't parse attributes of fields with GEOMETRY type

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -70,9 +70,10 @@ Loader.prototype.loadFixture = function(fixture, models) {
 
         var where = {};
         Object.keys(Model.rawAttributes).forEach(function(k) {
-            if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1)) {
+            var fieldType = Model.rawAttributes[k].type.constructor.key;
+            if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1) && fieldType != "GEOMETRY") {
                 //postgres 
-                if (Model.rawAttributes[k].type.constructor.key === 'JSONB') {
+                if (fieldType === 'JSONB') {
                     where[k] = {
                         $contains: data[k]
                     };


### PR DESCRIPTION
Sequelize expects an object for ['geometry'](http://docs.sequelizejs.com/en/latest/api/datatypes/#geometry) field types in postgres and mysql.  

Currently attributes are being parsed to become part of a 'where' clause, by ignoring geometry types we can add geographic data using JSON like so:

```
.. {
    "model": "region",
    "geometry": {
        "type": "Polygon",
        "coordinates": [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0]]]
    }
} ...
```
