### PR TITLE
Do not parse attributes of fields with VIRTUAL type

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -71,7 +71,7 @@ Loader.prototype.loadFixture = function(fixture, models) {
         var where = {};
         Object.keys(Model.rawAttributes).forEach(function(k) {
             var fieldType = Model.rawAttributes[k].type.constructor.key;
-            if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1) && fieldType !== 'GEOMETRY') {
+            if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1) && fieldType !== 'GEOMETRY' && fieldType !== 'VIRTUAL') {
                 //postgres 
                 if (fieldType === 'JSONB') {
                     where[k] = {


### PR DESCRIPTION
VIRTUAL fields should be ignored as they can not be included in queries.