### PR TITLE
Return models when loading fixtures

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -5,13 +5,14 @@ var Loader = module.exports = function(options) {
     this.options = options;
     this.saved = 0;
     this.skipped = 0;
+    this.fixtureModels = {};
 };
 
 Loader.prototype.loadFixtures = function(fixtures, models) {
     return Promise.each(fixtures, function(fixture) {
         return this.loadFixture(fixture, models);
     }.bind(this)).then(function() {
-        return Promise.resolve(this.saved);
+        return Promise.resolve([this.saved, this.fixtureModels]);
     }.bind(this));
 };
 
@@ -102,6 +103,10 @@ Loader.prototype.loadFixture = function(fixture, models) {
         return Model.find(findOptions).then(function(instance) {
             if (instance) {
                 self.skipped++;
+                if (!self.fixtureModels[Model.name]) {
+                    self.fixtureModels[Model.name] = [];
+                }
+                self.fixtureModels[Model.name].push(instance);
                 return setManyToMany(instance);
             }
 
@@ -117,6 +122,11 @@ Loader.prototype.loadFixture = function(fixture, models) {
                 .save(saveOptions).then(function(instance) {
                     if (instance) {
                         self.saved++;
+                        if (!self.fixtureModels[Model.name]) {
+                            self.fixtureModels[Model.name] = [];
+                        }
+                        self.fixtureModels[Model.name].push(instance);
+                        
                         return setManyToMany(instance);
                     }
                 });

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -12,7 +12,7 @@ Loader.prototype.loadFixtures = function(fixtures, models) {
     return Promise.each(fixtures, function(fixture) {
         return this.loadFixture(fixture, models);
     }.bind(this)).then(function() {
-        return Promise.resolve([this.saved, this.fixtureModels]);
+        return Promise.resolve({count:this.saved, models:this.fixtureModels});
     }.bind(this));
 };
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -150,6 +150,15 @@ describe('fixture (with promises)', function() {
             });
     });
 
+    it('should return model count and models', function() {
+        return sf.loadFile('tests/fixtures/fixture1.json', models)
+            .then(function(retVal) {
+                retVal.count.should.equal(3);
+                retVal.models.foo.length.should.equal(2);
+                retVal.models.bar.length.should.equal(1);
+            });
+    });
+
     it('should load fixtures from js (implied relative)', function() {
         return sf.loadFile('tests/fixtures/fixture1.js', models)
             .then(function() {


### PR DESCRIPTION
I wanted the models right away after loading them, so I am storing the created sequelize instances and then returning them in the loadFixtures function.

This would be a breaking change if anyone was using the count from the resolved argument from loadFixtures.