### PR TITLE
Fix "through" associations

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -57,7 +57,7 @@ Loader.prototype.loadFixture = function(fixture, models) {
                         //make options object with transaction if any, through table attrs if any
                         var options = objectAssign({},
                             self.options.transaction ? {transaction: self.options.transaction} : {},
-                            relinst._through || {});
+                          { through: relinst._through || {}});
 
                         //and add related instance
                         promises.push(instance[assoc.accessors.add](relinst.instance, options));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "sequelize fixture loader",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha tests"
+    "test": "./node_modules/.bin/mocha $NODE_DEBUG_OPTION tests"
   },
   "engines": {
     "node": "*"
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "sequelize": "^3.0.0",
+    "sequelize": "^4.0.0",
     "should": "*",
     "sinon": "^1.14.1",
     "sqlite3": "*"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "sequelize fixture loader",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha $NODE_DEBUG_OPTION tests"
+    "test": "./node_modules/.bin/mocha tests"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
In sequelize 4.x, attributes on join tables need to be specified inside a `through` attribute of the `options` object, instead of being included directly in our base.

This fixes the problem highlighted in #83 