### PR TITLE
Use sequelize's bundled copy of bluebird if it is available

### DIFF
--- a/lib/Promise.js
+++ b/lib/Promise.js
@@ -1,0 +1,9 @@
+let Promise;
+try {
+  Promise = require('sequelize').Promise;
+  if (!Promise) throw new Error();
+} catch (err) {
+  Promise = require('bluebird');
+}
+
+module.exports = Promise;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,4 +1,4 @@
-var Promise = require('bluebird');
+var Promise = require('./Promise');
 var objectAssign = require('object-assign');
 
 var Loader = module.exports = function(options) {
@@ -72,7 +72,7 @@ Loader.prototype.loadFixture = function(fixture, models) {
         Object.keys(Model.rawAttributes).forEach(function(k) {
             var fieldType = Model.rawAttributes[k].type.constructor.key;
             if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1) && fieldType !== 'GEOMETRY' && fieldType !== 'VIRTUAL') {
-                //postgres 
+                //postgres
                 if (fieldType === 'JSONB') {
                     where[k] = {
                         $contains: data[k]

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -1,4 +1,4 @@
-var Promise = require('bluebird'),
+var Promise = require('./Promise'),
     path    = require('path'),
     yaml    = require('js-yaml'),
     glob    = Promise.promisify(require('glob')),


### PR DESCRIPTION
Sequelize's [Managed Transactions](http://docs.sequelizejs.com/manual/tutorial/transactions.html) often do not work correctly in conjunction with sequelize-fixtures.  

For instance, this example shows a case where a managed transaction works correctly, as well as a case where sequelize-fixtures causes the transaction's "context" to be lost:

```js
sequelize.transaction(function () {
  models.person.findAll();  // will automatically use the transaction 
  return sequelize_fixtures.loadFile('fixtures/test_data.json', models).then(function(){
        return models.person.findAll(); // will NOT automatically use the transaction
  });
});
```

---

sequelize-fixtures depends on Bluebird 2.x, while most recent versions of Sequelize depend on Bluebird 3.x.  As a result, npm will install two different copies of Bluebird, and Sequelize and sequelize-fixtures will end up using completely different copies of Bluebird.

The API of Bluebird 2.x is similar enough to 3.x that most users aren't going to care that sequelize-fixtures is using an older version.  However, Sequelize's automatic/managed transaction functionality utilizes [CLS](https://github.com/othiym23/node-continuation-local-storage#readme), which can only be used with Bluebird if a special [patch](https://github.com/TimBeyer/cls-bluebird) is applied to the Bluebird instance.

While Sequelize patches the instance of bluebird that it uses internally, the version used by sequelize-fixtures is not patched.

tl;dr; We can sidestep this entire issue (while also avoiding any huge compatibility breaks for existing users) by grabbing Sequelize's copy of bluebird instead of providing our own.