### PR TITLE
Added JSON field type compatibility on fixtures

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -77,6 +77,8 @@ Loader.prototype.loadFixture = function(fixture, models) {
                     where[k] = {
                         $contains: data[k]
                     };
+                } else if (fieldType === 'JSON') {
+                    where[k] = JSON.stringify(data[k]);
                 } else if (Model.rawAttributes[k].hasOwnProperty('set')) {
                     var val = null;
                     Model.setDataValue = function(name, value) {

--- a/tests/fixtures/jsonContainingArray.js
+++ b/tests/fixtures/jsonContainingArray.js
@@ -1,0 +1,8 @@
+module.exports = [
+  {
+    "model":"SimpleJson",
+    "data": {
+      "props": {"home": ["latest", "get"]}
+    }
+  }
+];

--- a/tests/models/SimpleJson.js
+++ b/tests/models/SimpleJson.js
@@ -1,0 +1,5 @@
+module.exports = function (sequelize, DataTypes) {
+  return sequelize.define("simple_json", {
+      props: {type: DataTypes.JSON}
+  });
+};

--- a/tests/models/index.js
+++ b/tests/models/index.js
@@ -22,7 +22,8 @@ exports.all = [];
     'JsonbTestModel',
     'JsonSerializedTestModel',
     'ActorsMovies',
-    'Account'
+    'Account',
+    'SimpleJson'
 ].forEach( function (model) {
     var mod = sequelize.import(__dirname + '/' + model);
     module.exports[model] = mod;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -664,6 +664,16 @@ describe('fixture (with promises)', function() {
           should.exist(account);
         });
     });
+
+    it('should handle json including arrays', function() {
+      return sf.loadFile('tests/fixtures/jsonContainingArray.js', models)
+        .then(function() {
+            return models.SimpleJson.findAll();
+        }).then(function(models) {
+            models.length.should.equal(1);
+            models[0].props.should.match({"home": ["latest", "get"]});
+        });
+    });
     /* postgres only
     it('should handle jsonb fields', function() {
         return  sf.loadFile('tests/fixtures/jsonb.json', models)


### PR DESCRIPTION
Whenever a new fixture contains a JSON field which includes an array, the SELECT query that is performed before the actual insertion of the fixture record, fails.
The reason for the query to fail is due to a wrong check over the JSON array items, regardless of the used database:

```
(`user_level`.`level`->>\'$."home"\') = \'latest\', \'test\'
```
this query should check that the level.home item is an array being `['latest', 'test']`.

This pull requests foresees the JSON field differentiation to handle a proper check and subsequent insertion.
Unit test to validate the change is included within the PR.
