### PR TITLE
support using sequelize with `operatorAliases: false`

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,5 +1,6 @@
 var Promise = require('bluebird');
 var objectAssign = require('object-assign');
+var Op = require('sequelize').Op;
 
 var Loader = module.exports = function(options) {
     this.options = options;
@@ -72,11 +73,10 @@ Loader.prototype.loadFixture = function(fixture, models) {
         Object.keys(Model.rawAttributes).forEach(function(k) {
             var fieldType = Model.rawAttributes[k].type.constructor.key;
             if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1) && fieldType !== 'GEOMETRY' && fieldType !== 'VIRTUAL') {
-                //postgres 
+                //postgres
                 if (fieldType === 'JSONB') {
-                    where[k] = {
-                        $contains: data[k]
-                    };
+                    where[k] = {};
+                    where[k][Op.contains] = data[k];
                 } else if (Model.rawAttributes[k].hasOwnProperty('set')) {
                     var val = null;
                     Model.setDataValue = function(name, value) {


### PR DESCRIPTION
Sequelize keeps producing warnings about operatorAliases not being set to false. However when I set it to false I cannot load my fixtures. The reason for that is the JSONB type in Postgres. There was a workaround for it added in #51 and #55, and this workaround uses operator alias `$contains`. 

This PR proposes a simple change to fix that issue. 

Steps to reproduce:
1) Configure Postgres and `operatorAliases: false` in sequelize
2) Create a model with JSONB field
3) Create a fixture for it with a value which is i.e. an array or an object
4) Try to add the fixture