### PR TITLE
Updated version of js-yarn.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bluebird": "^2.4.2",
     "glob": "~7.0.5",
-    "js-yaml": "~2.1.0",
+    "js-yaml": "^3.3.5",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi. When I did `yarn audit` in my project I have got an error:
<img width="562" alt="screen shot 2018-12-18 at 16 48 57" src="https://user-images.githubusercontent.com/14975592/50211439-4da78700-0381-11e9-96fc-46de1538c240.png">

To fix it, we only need to change the version of js-yaml in `package.json` to `^3.3.5`

[Link to the issue](https://github.com/domasx2/sequelize-fixtures/issues/94)