### PR TITLE
Grunt: add support for async model loading

### DIFF
--- a/tasks/fixtures.js
+++ b/tasks/fixtures.js
@@ -1,30 +1,45 @@
 var sf = require('../index');
 
 module.exports = function(grunt) {
-    grunt.task.registerMultiTask('fixtures', 'Load fixtures', function () {
-        var data = this.data,
+    grunt.task.registerMultiTask('fixtures', 'Load fixtures', function() {
+        var taskInstance = this,
+            data = this.data,
             models = data.models,
             done = this.async(),
-            options = data.options  || {},
-            loader;
+            options = data.options || {},
+            loadFiles = function(models) {
+                var sources = [];
+                taskInstance.files.forEach(function(f) {
+                    [].push.apply(sources, f.src);
+                });
+                if (sources.length) {
+                    sf.loadFiles(sources, models, options)
+                        .then(function(numSaved) {
+                            grunt.log.ok(numSaved + ' fixtures loaded.');
+                            done();
+                        });
+                } else {
+                    throw new Error('no sources provided');
+                }
+            };
+
+        // link grunt logging to internal, if not specified
+        options.log = options.log || grunt.verbose.writeln;
 
         if (typeof models == 'string') {
+            grunt.verbose.writeln('Loading models using file path: ' + models);
             models = require(models);
         } else if (models.call) {
-            models = models();
+            grunt.verbose.writeln('Loading models using function callback...');
+            models = models.call(taskInstance, options);
+            if (models.then) {
+              models.then(function(loadedModels) {
+                return loadFiles(loadedModels);
+              });
+            } else {
+              loadFiles(models);
+            }
         }
 
-        var sources = [];
-        this.files.forEach(function(f){
-            [].push.apply(sources, f.src);
-        });
-        if (sources.length) {
-            sf.loadFiles(sources, models, options).then(function(saved){
-                console.log(saved+' fixtures loaded.');
-                done();
-            });
-        } else {
-            throw new Error('no sources provided');
-        }
     });
 };


### PR DESCRIPTION
Fixed issue #101
- add async support in models loader callback
- wire grunt logging to logging system
- remove unused variable from file