### PR TITLE
Fix for loading geography fields.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -246,7 +246,7 @@ Loader.prototype.prepFixtureData = function(data, Model) {
             if (Model.rawAttributes.hasOwnProperty(key)) {
                 result[key] = val;
             } else {
-                this.logger.warn('attribute "' + key +"' not defined on  model '" + Model.name + "'.");
+                console.warn('attribute "' + key +"' not defined on  model '" + Model.name + "'.");
             }
         }
     });

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -79,7 +79,7 @@ Loader.prototype.loadFixture = function(fixture, models) {
         var where = {};
         Object.keys(Model.rawAttributes).forEach(function(k) {
             var fieldType = Model.rawAttributes[k].type.constructor.key;
-            if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1) && fieldType !== 'GEOMETRY' && fieldType !== 'VIRTUAL') {
+            if (data.hasOwnProperty(k) && (!fixture.keys || fixture.keys.indexOf(k) !== -1) && fieldType !== 'GEOMETRY' && fieldType !== 'GEOGRAPHY' && fieldType !== 'VIRTUAL') {
                 //postgres
                 if (fieldType === 'JSONB') {
                   where[k] = {};


### PR DESCRIPTION
Currently if there is a field of geography type defined like this:

`    geoPosition: {
      type: GEOGRAPHY('POINT', 4326),
    },`

and you try to load it in fixtures like this:

`
....
"geoPosition": {"type": "Point", "coordinates": [39.807222, -76.984722]},
...
`

the query that sequelize-fixtures generate to check if the record is in DB contains the following fragment in the `WHERE` section:

`...("ResidentialRealEstate"."geoPosition" = ST_GeomFromGeoJSON('{"type":"Point"}') AND "ResidentialRealEstate"."geoPosition" = ST_GeomFromGeoJSON('{"coordinates":[39.807222,-76.984722]}'))...`

This should be handled in the same manner as geometry field.