### PR TITLE
Fix loading models with json columns

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -85,7 +85,7 @@ Loader.prototype.loadFixture = function(fixture, models) {
                   where[k] = {};
                   where[k][Op.contains] = data[k];
                 } else if (fieldType === 'JSON') {
-                    where[k] = JSON.stringify(data[k]);
+                    where[k] = data[k];
                 } else if (Model.rawAttributes[k].hasOwnProperty('set') && !ignoreSet) {
                     var val = null;
                     // create a simulated setDataValue method, which is commonly


### PR DESCRIPTION
Comparing json with text yields an error on Sequelize v5. If you just pass along the object, Sequelize will use the appropriate comparison operator.