### PR TITLE
Fix duplicate detection to work with JSON arrays

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -85,7 +85,11 @@ Loader.prototype.loadFixture = function(fixture, models) {
                   where[k] = {};
                   where[k][Op.contains] = data[k];
                 } else if (fieldType === 'JSON') {
-                    where[k] = JSON.stringify(data[k]);
+                    // Can't use JSON.strinfigy because PostgreSQL doesn't
+                    // compare JSON with string and SQLite fails silently to
+                    // compare, but can't use plain object because the SQLite
+                    // dialect doesn't support arrays.
+                    where[k] = serializeArrays(data[k]);
                 } else if (Model.rawAttributes[k].hasOwnProperty('set') && !ignoreSet) {
                     var val = null;
                     // create a simulated setDataValue method, which is commonly
@@ -254,4 +258,12 @@ Loader.prototype.prepFixtureData = function(data, Model) {
     return Promise.all(promises).then(function() {
         return [result, many2many];
     });
+};
+
+serializeArrays = function(obj) {
+    if (typeof obj !== 'object' || obj === null) return obj;
+    if (Array.isArray(obj)) return JSON.stringify(obj);
+    return Object.keys(obj)
+        .map(k => ({ [k]: serializeArrays(obj[k]) }))
+        .reduce((acc, curr) => Object.assign(acc, curr), {});
 };

--- a/tests/models/Foo.js
+++ b/tests/models/Foo.js
@@ -2,6 +2,7 @@ module.exports = function (sequelize, DataTypes) {
     return sequelize.define("foo", {
         propA: {type: DataTypes.STRING},
         propB: {type: DataTypes.INTEGER},
-        status: {type: DataTypes.BOOLEAN}
+        status: {type: DataTypes.BOOLEAN},
+        payload: {type: DataTypes.JSON}
     });
 };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -13,7 +13,8 @@ var FOO_FIXTURE = {
     model: 'Foo',
     data: {
         propA: 'bar',
-        propB: 1
+        propB: 1,
+        payload: { number: 1, string: 'value', array: [], null: null }
     }
 };
 


### PR DESCRIPTION
So the issue isn't as simple as I hoped initially, sorry for the previous broken build. Here's the conundrum previously happening:

- If you don't serialize, the syntax will fail when the JSON field contains arrays because the SQLite dialect doesn't handle arrays properly (SQLite doesn't have array types).
- If you do serialize the entire object, the comparison fails on PostgreSQL where you can't compare JSON and string, and fails silently on SQLite (thus inserting duplicate objects, breaking another test)

So I implemented a small helper that recursively serializes only arrays, making all tests pass.