### PR TITLE
Printing the actual error message when Model.set fails

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -102,7 +102,7 @@ Loader.prototype.loadFixture = function(fixture, models) {
                       // don't include VIRTUAL column in filter condition
                       where[k] = val;
                     } catch (err) {
-                      throw new Error('Error using Model.set method for model ' + fixture.model + ' property ' + k + ' (possibly due to the use of instance methods). You should use option ignoreSet: true');
+                      throw new Error('Error using Model.set method for model ' + fixture.model + ' property ' + k + ' (possibly due to the use of instance methods). You should use option ignoreSet: true.\n' + err);
                     }
                 } else {
                     where[k] = data[k];


### PR DESCRIPTION
If the function provided via `set` throws an error, it will hide the error message, which makes it hard to debug.

```js
  column: {
    ...
    set: () => { throw new Error('foo bar') }
  },
```

before:

```
Error: Error using Model.set method for model Product property ... (possibly due to the use of instance methods). You should use option ignoreSet: true.
    at node_modules/sequelize-fixtures/lib/loader.js:105:29
```

after:

```
Error: Error using Model.set method for model Product property ... (possibly due to the use of instance methods). You should use option ignoreSet: true.
Error: foo bar
    at node_modules/sequelize-fixtures/lib/loader.js:105:29
```